### PR TITLE
fix: make hooks cancelable in non-mux mode

### DIFF
--- a/hooks/bash.sh
+++ b/hooks/bash.sh
@@ -32,7 +32,11 @@ _direnv_hook() {
     eval "$(<"$__DIRENV_INSTANT_ENV_FILE")"
   fi
 
+  local previous_exit_status=$?;
+  trap -- '' SIGINT;
   eval "$(direnv-instant start)"
+  trap - SIGINT;
+  return $previous_exit_status;
 }
 
 # Cleanup on shell exit

--- a/hooks/zsh.sh
+++ b/hooks/zsh.sh
@@ -33,7 +33,9 @@ _direnv_hook() {
     eval "$(<"$__DIRENV_INSTANT_ENV_FILE")"
   fi
 
+  trap -- '' SIGINT
   eval "$(direnv-instant start)"
+  trap - SIGINT
 }
 
 # Cleanup on shell exit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves reliability of environment initialization in Bash and Zsh by temporarily ignoring interrupt signals during startup, preventing partial setup when pressing Ctrl-C.
  * Preserves and restores the previous command’s exit status after initialization, ensuring prompts, conditional logic, and scripts behave correctly.
  * Restores normal interrupt handling immediately after startup for consistent shell usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->