### PR TITLE
Handle PROMPT_COMMAND being an array and don't strip it

### DIFF
--- a/hooks/bash.sh
+++ b/hooks/bash.sh
@@ -55,10 +55,12 @@ if [[ -z ${__DIRENV_INSTANT_HOOKED} ]]; then
   trap '_direnv_exit_cleanup' EXIT
 
   # Register bash PROMPT_COMMAND hook
-  if [[ -z ${PROMPT_COMMAND} ]]; then
-    PROMPT_COMMAND="_direnv_hook"
-  elif [[ ! ${PROMPT_COMMAND} =~ (^|;)[[:space:]]*_direnv_hook($|;) ]]; then
-    PROMPT_COMMAND="_direnv_hook;${PROMPT_COMMAND}"
+  if [[ ";${PROMPT_COMMAND[*]:-};" != *";_direnv_hook;"* ]]; then
+    if [[ "$(declare -p PROMPT_COMMAND 2>&1)" == "declare -a"* ]]; then
+      PROMPT_COMMAND=(_direnv_hook "${PROMPT_COMMAND[@]}")
+    else
+      PROMPT_COMMAND="_direnv_hook${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+    fi
   fi
 
   # Run initial hook


### PR DESCRIPTION
see https://github.com/direnv/direnv/blob/03bc1a5cd75bd41c0cc62ed64e94e0de43596c20/internal/cmd/shell_bash.go#L19-L25

I have the following in my bashrc:

``` 
echo 1
echo "${PROMPT_COMMAND[@]}"
declare -p PROMPT_COMMAND
echo 1
eval "$(direnv-instant hook bash)"
echo 2
echo "${PROMPT_COMMAND[@]}"
declare -p PROMPT_COMMAND
echo 2
``` 

Before:

```
1
_sbp_set_prompt;__bp_trap_string="$(trap -p DEBUG)"
trap - DEBUG
__bp_install history -a history -c history -r
declare -a PROMPT_COMMAND=([0]=$'_sbp_set_prompt;__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_install' [1]="history -a" [2]="history -c" [3]="history -r")
1
2
_direnv_hook;_sbp_set_prompt;__bp_trap_string="$(trap -p DEBUG)"
trap - DEBUG
__bp_install history -a history -c history -r
declare -a PROMPT_COMMAND=([0]=$'_direnv_hook;_sbp_set_prompt;__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_install' [1]="history -a" [2]="history -c" [3]="history -r")
2
```

after:
```
1
_sbp_set_prompt;__bp_trap_string="$(trap -p DEBUG)"
trap - DEBUG
__bp_install history -a history -c history -r
declare -a PROMPT_COMMAND=([0]=$'_sbp_set_prompt;__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_install' [1]="history -a" [2]="history -c" [3]="history -r")
1
2
_direnv_hook _sbp_set_prompt;__bp_trap_string="$(trap -p DEBUG)"
trap - DEBUG
__bp_install history -a history -c history -r
declare -a PROMPT_COMMAND=([0]="_direnv_hook" [1]=$'_sbp_set_prompt;__bp_trap_string="$(trap -p DEBUG)"\ntrap - DEBUG\n__bp_install' [2]="history -a" [3]="history -c" [4]="history -r")
2
Share files via qr codes with `qrcp
```