### PR TITLE
home/nixos: only force-disable direnv hooks when our hook is enabled

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -93,9 +93,12 @@ in
       programs.direnv = {
         enable = lib.mkDefault true;
         # direnv and direnv-instant have mutually exclusive hooks
-        enableBashIntegration = lib.mkForce (!cfg.enableBashIntegration);
-        enableFishIntegration = lib.mkForce (!cfg.enableFishIntegration);
-        enableZshIntegration = lib.mkForce (!cfg.enableZshIntegration);
+        enableBashIntegration = lib.mkIf cfg.enableBashIntegration (lib.mkForce false);
+        enableZshIntegration = lib.mkIf cfg.enableZshIntegration (lib.mkForce false);
+        # Note: We cannot disable enableFishIntegration because home-manager
+        # declares it as read-only. This means direnv's fish hook may run
+        # alongside direnv-instant's hook. See:
+        # https://github.com/Mic92/direnv-instant/issues/35
       };
 
       home.packages = [ finalPackage ];

--- a/nixos.nix
+++ b/nixos.nix
@@ -97,9 +97,9 @@ in
       programs.direnv = {
         enable = lib.mkDefault true;
         # direnv and direnv-instant have mutually exclusive hooks
-        enableBashIntegration = lib.mkForce (!cfg.enableBashIntegration);
-        enableZshIntegration = lib.mkForce (!cfg.enableZshIntegration);
-        enableFishIntegration = lib.mkForce (!cfg.enableFishIntegration);
+        enableBashIntegration = lib.mkIf cfg.enableBashIntegration (lib.mkForce false);
+        enableZshIntegration = lib.mkIf cfg.enableZshIntegration (lib.mkForce false);
+        enableFishIntegration = lib.mkIf cfg.enableFishIntegration (lib.mkForce false);
       };
 
       environment.systemPackages = [ finalPackage ];


### PR DESCRIPTION

Use mkIf to conditionally apply mkForce, so we only override direnv's
shell integration when direnv-instant's integration is enabled for that
shell. This avoids forcing values when users disable our integration.

Also document that home-manager's enableFishIntegration is read-only,
so we cannot disable direnv's fish hook there. Both hooks will run
simultaneously for fish users on home-manager.

Related: https://github.com/Mic92/direnv-instant/issues/35


