### PR TITLE
fix(kitty): create window in current process tab instead of focused tab

### DIFF
--- a/src/mux.rs
+++ b/src/mux.rs
@@ -65,7 +65,7 @@ impl Multiplexer {
                 "--",
             ],
             Multiplexer::Wezterm => vec!["cli", "split-pane", "--bottom", "--cells", PANE_HEIGHT],
-            Multiplexer::Kitty => vec!["launch", "--location", "vsplit", "--keep-focus"],
+            Multiplexer::Kitty => vec!["launch", "--location", "vsplit", "--keep-focus", "--self"],
         };
 
         let mut command = Command::new(mux_bin);


### PR DESCRIPTION
Add --self flag to kitty launch command to ensure new windows are created in the same tab as the current process.