### PR TITLE
fix(zsh): redraw prompt after async direnv output

### DIFF
--- a/hooks/zsh.sh
+++ b/hooks/zsh.sh
@@ -22,6 +22,10 @@ _direnv_handler() {
   if [[ -n $__DIRENV_INSTANT_ENV_FILE ]] && [[ -f $__DIRENV_INSTANT_ENV_FILE ]]; then
     eval "$(<"$__DIRENV_INSTANT_ENV_FILE")"
   fi
+
+  # Redraw the prompt after receiving output from direnv
+  # This ensures the prompt is displayed after async output
+  zle && zle .reset-prompt && zle -R
 }
 
 # Main hook called on directory changes and prompts


### PR DESCRIPTION
Fixes #48

When SIGUSR1 handler outputs direnv content in zsh, the prompt was not being redrawn, requiring the user to press Enter to see it again.

Add 'zle .reset-prompt' to force prompt redraw after handling async direnv output.
