### PR TITLE
hooks: use builtins/command prefix to bypass user aliases

### DIFF
--- a/hooks/bash.sh
+++ b/hooks/bash.sh
@@ -11,9 +11,9 @@ _direnv_handler() {
   # Display stderr output if available
   if [[ -n $__DIRENV_INSTANT_STDERR_FILE ]] && [[ -f $__DIRENV_INSTANT_STDERR_FILE ]]; then
     if [[ -s $__DIRENV_INSTANT_STDERR_FILE ]]; then
-      cat "$__DIRENV_INSTANT_STDERR_FILE"
+      printf '%s\n' "$(<"$__DIRENV_INSTANT_STDERR_FILE")"
     fi
-    rm -f "$__DIRENV_INSTANT_STDERR_FILE" 2>/dev/null || true
+    command rm -f "$__DIRENV_INSTANT_STDERR_FILE" 2>/dev/null || true
     __DIRENV_INSTANT_STDERR_FILE=""
   fi
 

--- a/hooks/fish.fish
+++ b/hooks/fish.fish
@@ -10,9 +10,9 @@ function _direnv_handler --on-signal USR1
     # Display stderr output if available
     if test -n "$__DIRENV_INSTANT_STDERR_FILE" -a -f "$__DIRENV_INSTANT_STDERR_FILE"
         if test -s "$__DIRENV_INSTANT_STDERR_FILE"
-            cat "$__DIRENV_INSTANT_STDERR_FILE"
+            command cat "$__DIRENV_INSTANT_STDERR_FILE"
         end
-        rm -f "$__DIRENV_INSTANT_STDERR_FILE" 2>/dev/null; or true
+        command rm -f "$__DIRENV_INSTANT_STDERR_FILE" 2>/dev/null; or true
         set -g __DIRENV_INSTANT_STDERR_FILE ""
     end
 

--- a/hooks/zsh.sh
+++ b/hooks/zsh.sh
@@ -12,7 +12,7 @@ _direnv_handler() {
   # Display stderr output if available
   if [[ -n $__DIRENV_INSTANT_STDERR_FILE ]] && [[ -f $__DIRENV_INSTANT_STDERR_FILE ]]; then
     if [[ -s $__DIRENV_INSTANT_STDERR_FILE ]]; then
-      echo "$(<"$__DIRENV_INSTANT_STDERR_FILE")"
+      printf '%s\n' "$(<"$__DIRENV_INSTANT_STDERR_FILE")"
     fi
     command rm -f "$__DIRENV_INSTANT_STDERR_FILE" 2>/dev/null || true
     __DIRENV_INSTANT_STDERR_FILE=""


### PR DESCRIPTION
Fixes #71

Users who alias cat to bat (common in fish configs) get a pager invoked when the SIGUSR1 handler replays direnv stderr output. The pager shows hundreds of lines of raw PTY progress updates that the user already saw in the mux pane.

Use shell builtins (printf + $(<file)) in bash/zsh to avoid forking entirely, and command cat/rm in fish to bypass function overrides.