### PR TITLE
home: remove fish readOnly workaround

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -2,7 +2,6 @@
   pkgs,
   lib,
   config,
-  options,
   ...
 }:
 let
@@ -28,11 +27,6 @@ let
     str
     ;
 
-  # On stable home-manager (<= 24.11), enableFishIntegration is read-only
-  # because direnv ships fish vendor functions that auto-load.
-  # On unstable home-manager, this was fixed and we can disable it.
-  # See: https://github.com/Mic92/direnv-instant/issues/35
-  fishIntegrationReadOnly = options.programs.direnv.enableFishIntegration.readOnly or false;
 in
 {
   options.programs.direnv-instant = {
@@ -102,10 +96,6 @@ in
         # direnv and direnv-instant have mutually exclusive hooks
         enableBashIntegration = lib.mkIf cfg.enableBashIntegration (lib.mkForce false);
         enableZshIntegration = lib.mkIf cfg.enableZshIntegration (lib.mkForce false);
-      }
-      // lib.optionalAttrs (!fishIntegrationReadOnly) {
-        # Only disable fish integration if the option is not read-only (unstable home-manager)
-        # On stable home-manager (<= 25.11), both direnv and direnv-instant hooks run for fish.
         enableFishIntegration = lib.mkIf cfg.enableFishIntegration (lib.mkForce false);
       };
 


### PR DESCRIPTION
Remove the `fishIntegrationReadOnly` detection added in PR #53.

Now that home-manager 26.05 will include the upstream fix ([aea57993a](https://github.com/nix-community/home-manager/commit/aea57993a89bfc2a66c0434e0f4383ebf164e2a3)), we can always set `enableFishIntegration = lib.mkIf cfg.enableFishIntegration (lib.mkForce false)` consistently with bash and zsh.

Closes #54