### PR TITLE
watch: propagate terminal size to PTY master

### DIFF
--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -1,4 +1,6 @@
 use crate::daemon::stop_daemon;
+use nix::libc;
+use nix::pty::Winsize;
 use nix::sys::select::{FdSet, select};
 use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 use nix::sys::socket::{ControlMessageOwned, MsgFlags, recvmsg};
@@ -14,9 +16,38 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 static WATCH_RUNNING: AtomicBool = AtomicBool::new(true);
+static SIGWINCH_RECEIVED: AtomicBool = AtomicBool::new(false);
 
 extern "C" fn sigint_handler(_: nix::libc::c_int) {
     WATCH_RUNNING.store(false, Ordering::SeqCst);
+}
+
+extern "C" fn sigwinch_handler(_: nix::libc::c_int) {
+    SIGWINCH_RECEIVED.store(true, Ordering::SeqCst);
+}
+
+/// Read the terminal window size from a file descriptor.
+fn get_winsize(fd: RawFd) -> Option<Winsize> {
+    let mut ws: Winsize = unsafe { std::mem::zeroed() };
+    let ret = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut ws) };
+    if ret == 0 { Some(ws) } else { None }
+}
+
+/// Set the terminal window size on a file descriptor.
+/// When called on a PTY master, the kernel delivers SIGWINCH to the
+/// child process group, causing programs like nix to re-read the size.
+fn set_winsize(fd: RawFd, ws: &Winsize) {
+    unsafe {
+        libc::ioctl(fd, libc::TIOCSWINSZ, ws);
+    }
+}
+
+/// Propagate our terminal size to the PTY master so the child process
+/// (e.g. nix) uses the actual pane width instead of a hardcoded default.
+fn propagate_winsize(pty_fd: RawFd) {
+    if let Some(ws) = get_winsize(libc::STDERR_FILENO) {
+        set_winsize(pty_fd, &ws);
+    }
 }
 
 /// RAII guard that restores terminal settings on drop
@@ -149,6 +180,17 @@ pub fn run(log_path: &Path, socket_path: &Path) {
         None
     };
 
+    // Propagate our terminal size to the PTY and track future resizes
+    if let Some(ref pty) = pty_master {
+        propagate_winsize(pty.as_raw_fd());
+
+        let winch_handler = SigHandler::Handler(sigwinch_handler);
+        let winch_action = SigAction::new(winch_handler, SaFlags::empty(), SigSet::empty());
+        unsafe {
+            let _ = sigaction(Signal::SIGWINCH, &winch_action);
+        }
+    }
+
     // Set stdin to raw mode for transparent input forwarding (only if we have PTY fd)
     let _raw_mode_guard = if pty_master.is_some() {
         RawModeGuard::new(&stdin)
@@ -164,6 +206,13 @@ pub fn run(log_path: &Path, socket_path: &Path) {
     let mut handle = stdout.lock();
 
     while WATCH_RUNNING.load(Ordering::SeqCst) {
+        // Propagate terminal resize to PTY when our pane is resized
+        if SIGWINCH_RECEIVED.swap(false, Ordering::SeqCst)
+            && let Some(ref pty) = pty_master
+        {
+            propagate_winsize(pty.as_raw_fd());
+        }
+
         let mut fds = FdSet::new();
         fds.insert(socket.as_fd());
         if stdin_is_terminal && pty_master.is_some() {

--- a/tests/test_watch_propagates_terminal_size.py
+++ b/tests/test_watch_propagates_terminal_size.py
@@ -1,0 +1,170 @@
+"""Test that the watch command propagates terminal size to the PTY.
+
+When direnv runs inside a PTY, programs like nix query the terminal
+width via ioctl(TIOCGWINSZ) and truncate output to fit. The watch
+command should propagate the actual tmux pane size to the PTY master
+so output isn't needlessly truncated (issue #49).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from tests.helpers import (
+    allow_direnv,
+    setup_envrc,
+    setup_test_env,
+)
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+    from tests.conftest import DirenvInstantRunner, SignalWaiter
+
+
+def test_watch_propagates_terminal_size(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    direnv_instant: DirenvInstantRunner,
+    signal_waiter: SignalWaiter,
+) -> None:
+    """Test that the watch pane's terminal size is propagated to the PTY.
+
+    The .envrc script reports the terminal width seen by the child
+    process. We create a wide (200-column) tmux session so the pane
+    width differs from the hardcoded 80-column PTY default. If the
+    watch command propagates its pane size, the child should see the
+    pane's actual width.
+    """
+    done_marker = tmp_path / "envrc_done"
+    cols_file = tmp_path / "cols_seen"
+
+    # .envrc that waits, then reports terminal columns visible on stderr
+    setup_envrc(
+        tmp_path,
+        f"""#!/usr/bin/env bash
+echo "waiting..." >&2
+while [ ! -f {done_marker} ]; do sleep 0.1; done
+# Report the terminal width the child process sees
+cols=$(stty size </dev/stderr 2>/dev/null | awk '{{print $2}}')
+echo "$cols" > {cols_file}
+echo "cols=$cols" >&2
+export DONE=1
+""",
+    )
+
+    allow_direnv(tmp_path, monkeypatch)
+
+    # Create a wide tmux session (200 columns) so the pane width
+    # differs from the hardcoded 80-column PTY default.
+    socket_path = tmp_path / "tmux-socket"
+    subprocess.run(
+        [
+            "tmux",
+            "-S",
+            str(socket_path),
+            "new-session",
+            "-d",
+            "-x",
+            "200",
+            "-y",
+            "50",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    try:
+        env = setup_test_env(tmp_path, signal_waiter.pid)
+        env["TMUX"] = f"{socket_path},0,0"
+
+        # Run direnv-instant start
+        result = direnv_instant.run(["start"], env)
+        assert result.returncode == 0, f"Failed: {result.stderr}"
+
+        env_file = None
+        for line in result.stdout.splitlines():
+            if "__DIRENV_INSTANT_ENV_FILE=" in line:
+                env_file_str = line.split("=", 1)[1].strip().strip("'\"")
+                env_file = Path(env_file_str)
+                break
+        assert env_file, "Could not find env file path"
+
+        # Wait for watch pane to appear
+        watch_pane_id = None
+        start = time.time()
+        while time.time() - start < 10:
+            list_panes = subprocess.run(
+                [
+                    "tmux",
+                    "-S",
+                    str(socket_path),
+                    "list-panes",
+                    "-a",
+                    "-F",
+                    "#{pane_id} #{pane_width} #{pane_current_command}",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            for line in list_panes.stdout.splitlines():
+                if "direnv-instant" in line or "watch" in line:
+                    watch_pane_id = line.split()[0]
+                    break
+
+            if watch_pane_id:
+                break
+            time.sleep(0.1)
+
+        assert watch_pane_id, f"Watch pane not found. Panes: {list_panes.stdout}"
+
+        # Get the watch pane's actual width
+        pane_width_result = subprocess.run(
+            [
+                "tmux",
+                "-S",
+                str(socket_path),
+                "display-message",
+                "-t",
+                watch_pane_id,
+                "-p",
+                "#{pane_width}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        pane_width = int(pane_width_result.stdout.strip())
+        assert pane_width > 80, (
+            f"Pane width is {pane_width}, expected >80 for this test"
+        )
+
+        # Unblock the .envrc so it reports the terminal width
+        done_marker.touch()
+
+        # Wait for completion
+        assert signal_waiter.wait_for_env_file(env_file, timeout=30), (
+            "Env file not created within timeout"
+        )
+
+        # Read the terminal width the child process saw
+        assert cols_file.exists(), "cols_seen file was not created"
+        cols_seen = int(cols_file.read_text().strip())
+
+        # The child should see the pane's width, not the hardcoded 80
+        assert cols_seen == pane_width, (
+            f"Child saw {cols_seen} columns but pane is {pane_width} wide. "
+            f"Watch command did not propagate terminal size."
+        )
+
+    finally:
+        subprocess.run(
+            ["tmux", "-S", str(socket_path), "kill-server"],
+            check=False,
+            capture_output=True,
+        )


### PR DESCRIPTION
Programs like nix query the PTY width via ioctl(TIOCGWINSZ) and truncate their progress bar output to fit. The daemon creates the PTY with a hardcoded 80-column width, but the watch command (running in a tmux/zellij pane) may have a different terminal size.

Propagate the watch pane's terminal size to the PTY master fd on startup via TIOCSWINSZ, and install a SIGWINCH handler to re-propagate whenever the pane is resized. The kernel delivers SIGWINCH to the child process group, causing nix to re-read the terminal size.

Closes: https://github.com/Mic92/direnv-instant/issues/49