### PR TITLE
zellij: close pane after direnv finishes

### DIFF
--- a/src/mux.rs
+++ b/src/mux.rs
@@ -62,6 +62,7 @@ impl Multiplexer {
                 "down",
                 "--width",
                 PANE_HEIGHT,
+                "--close-on-exit",
                 "--",
             ],
             Multiplexer::Wezterm => vec!["cli", "split-pane", "--bottom", "--cells", PANE_HEIGHT],


### PR DESCRIPTION

Zellij keeps spawned panes open after the command exits by default,
leaving a dead pane behind once the .envrc has loaded. Pass
--close-on-exit so the progress pane disappears like it does under
tmux.

Fixes #89
