### PR TITLE
fix(watch): retry select() on EINTR instead of exiting

### DIFF
--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -261,6 +261,9 @@ pub fn run(log_path: &Path, socket_path: &Path) {
                     }
                 }
             }
+            // Signal (e.g. SIGWINCH from the multiplexer on pane creation)
+            // interrupted select; retry instead of exiting.
+            Err(e) if e == nix::errno::Errno::EINTR => continue,
             Err(_) => break,
         }
 

--- a/tests/test_watch_survives_sigwinch.py
+++ b/tests/test_watch_survives_sigwinch.py
@@ -1,0 +1,73 @@
+"""Regression test for #105: select() EINTR must not kill watch loop."""
+
+from __future__ import annotations
+
+import os
+import pty
+import signal
+import socket
+import struct
+import subprocess
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.conftest import DirenvInstantRunner
+
+
+def test_watch_survives_sigwinch(
+    tmp_path: Path,
+    direnv_instant: DirenvInstantRunner,
+) -> None:
+    log_path = tmp_path / "watch.log"
+    log_path.touch()
+    socket_path = tmp_path / "daemon.sock"
+
+    # Watch needs a TTY stdin to request the PTY fd from the daemon.
+    master_fd, slave_fd = pty.openpty()
+
+    daemon_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    daemon_sock.bind(str(socket_path))
+    daemon_sock.listen(2)
+
+    watch_proc = subprocess.Popen(
+        [direnv_instant.binary_path, "watch", str(log_path), str(socket_path)],
+        stdin=slave_fd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    os.close(slave_fd)
+    monitoring_conn: socket.socket | None = None
+    try:
+        # WATCH request → reply with PTY master fd over SCM_RIGHTS.
+        watch_conn, _ = daemon_sock.accept()
+        with watch_conn:
+            assert watch_conn.recv(64).startswith(b"WATCH")
+            watch_conn.sendmsg(
+                [b"OK\n"],
+                [(socket.SOL_SOCKET, socket.SCM_RIGHTS, struct.pack("i", master_fd))],
+            )
+        # Long-lived monitoring connection; watch exits when daemon closes it.
+        monitoring_conn, _ = daemon_sock.accept()
+
+        time.sleep(0.5)
+        assert watch_proc.poll() is None, "watch exited before SIGWINCH"
+
+        os.kill(watch_proc.pid, signal.SIGWINCH)
+        time.sleep(0.5)
+
+        assert watch_proc.poll() is None, (
+            f"watch exited after SIGWINCH (rc={watch_proc.returncode})"
+        )
+    finally:
+        if monitoring_conn is not None:
+            monitoring_conn.close()
+        daemon_sock.close()
+        os.close(master_fd)
+        try:
+            watch_proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            watch_proc.kill()
+            watch_proc.wait()


### PR DESCRIPTION
## Problem

  When `direnv-instant` spawns a multiplexer pane (e.g. `zellij action new-pane`), the
  multiplexer sends `SIGWINCH` to the new pane process to inform it of the terminal size.
  `SIGWINCH` interrupts the watch process's `select()` call, which returns `EINTR`.

  The current code treats any `select()` error as fatal:

  ```rust
  Err(_) => break,
```

  This causes the watch process to exit ~15ms after starting. With --close-on-exit (used by
  the zellij integration), the pane disappears before the user can see anything.

  ## Reproduction

  In a zellij session, trigger a slow direnv evaluation. The pane is supposed to spawn and
  remain visible while direnv runs. Instead it appears and vanishes in under 20ms.

  Trace excerpt (with diagnostic logging):

  ```
  watch] run() entered
  watch] pre-loop: stdin_is_terminal=true pty_master=true
  watch] loop iter 1
  watch] select err: EINTR: Interrupted system call
  watch] loop exited after 1 iter(s), reason: select error
  ```

  15ms total. SIGWINCH from zellij interrupted the first select() and the loop bailed.

  ## Fix

  Treat EINTR as a retry signal — exactly what POSIX intends:

  ```rust
  Err(e) if e == nix::errno::Errno::EINTR => continue,
  Err(_) => break,
  ```

  After this fix, watch correctly stays alive for the full duration of the daemon's run,
  then exits cleanly via the existing socket-EOF path.

  ## Tests

  Adds `tests/test_watch_survives_sigwinch.py`. The test runs `direnv-instant watch`
  directly against a mock daemon socket (handing off a PTY master fd via `SCM_RIGHTS`,
  matching the real daemon's protocol) and delivers `SIGWINCH` to the watch process.
  This exercises the EINTR-during-`select()` path deterministically, without depending
  on which multiplexer happens to send `SIGWINCH` on pane creation. With the EINTR retry
  removed, the test fails with `watch exited after SIGWINCH (rc=0)`; with the fix in
  place it passes in ~1s.

  ## Impact

  This fixes pane visibility in any multiplexer that delivers a signal during pane creation.