### PR TITLE
feat: add Nushell support (#90)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
                 clippy
                 rust-analyzer
                 fish
+                nushell
               ];
             };
 

--- a/hooks/nushell.nu
+++ b/hooks/nushell.nu
@@ -1,0 +1,56 @@
+# direnv-instant hook for Nushell.
+#
+# Nushell has no signal-trap mechanism, so unlike the bash/zsh/fish hooks
+# this one cannot react to SIGUSR1 from the daemon. Instead it polls the
+# env file at pre_prompt and pre_execution. The binary speaks JSON because
+# `source` in nu is parse-time and cannot evaluate dynamic command output.
+#
+# All env mutations happen in a single `--env` def call to dodge a nushell
+# quirk where hide-env after load-env across separate `--env` defs in the
+# same call chain does not propagate.
+
+def _direnv_instant_load_file [path: string]: nothing -> record {
+    if ($path | is-empty) or not ($path | path exists) { return {} }
+    open --raw $path | from json | default {}
+}
+
+def --env _direnv_instant_apply [data: record] {
+    let to_load = (
+        $data | items {|k v| {key: $k, val: $v} } | where val != null
+        | reduce -f {} {|it acc| $acc | upsert $it.key $it.val }
+    )
+    let to_unset = ($data | items {|k v| if $v == null { $k } } | compact)
+    for k in $to_unset { hide-env --ignore-errors $k }
+    if not ($to_load | is-empty) { load-env $to_load }
+}
+
+def --env _direnv_instant_show_stderr [] {
+    let f = ($env.__DIRENV_INSTANT_STDERR_FILE? | default "")
+    if ($f | is-empty) or not ($f | path exists) { return }
+    let content = (open --raw $f)
+    if not ($content | is-empty) { print --stderr $content }
+    rm --force $f
+}
+
+def --env _direnv_instant_hook [] {
+    $env.DIRENV_INSTANT_SHELL = "nu"
+    $env.DIRENV_INSTANT_SHELL_PID = ($nu.pid | into string)
+    let cached = (_direnv_instant_load_file ($env.__DIRENV_INSTANT_ENV_FILE? | default ""))
+    let raw = (^direnv-instant start | str trim)
+    let state = if ($raw | is-empty) { {} } else { $raw | from json }
+    let next_file = ($state.__DIRENV_INSTANT_ENV_FILE? | default ($env.__DIRENV_INSTANT_ENV_FILE? | default ""))
+    let fresh = (_direnv_instant_load_file $next_file)
+    _direnv_instant_apply ($cached | merge $state | merge $fresh)
+    _direnv_instant_show_stderr
+}
+
+export-env {
+    $env.config = ($env.config? | default {})
+    $env.config.hooks = ($env.config.hooks? | default {})
+    $env.config.hooks.pre_prompt = (
+        ($env.config.hooks.pre_prompt? | default []) | append { _direnv_instant_hook }
+    )
+    $env.config.hooks.pre_execution = (
+        ($env.config.hooks.pre_execution? | default []) | append { _direnv_instant_hook }
+    )
+}

--- a/src/commands/hook.rs
+++ b/src/commands/hook.rs
@@ -3,6 +3,7 @@ pub fn run(shell: &str) {
         "zsh" => print!("{}", include_str!("../../hooks/zsh.sh")),
         "bash" => print!("{}", include_str!("../../hooks/bash.sh")),
         "fish" => print!("{}", include_str!("../../hooks/fish.fish")),
+        "nu" | "nushell" => print!("{}", include_str!("../../hooks/nushell.nu")),
         _ => {
             eprintln!("Unsupported shell: {}", shell);
             std::process::exit(1);

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -2,6 +2,7 @@ use crate::daemon::{
     DaemonContext, direnv_export_command, get_socket_path, notify_daemon, start_daemon, stop_daemon,
 };
 use crate::mux::Multiplexer;
+use crate::nushell;
 use crate::shell::Shell;
 use nix::unistd::getppid;
 use std::env;
@@ -10,12 +11,18 @@ use std::path::PathBuf;
 use std::process::Stdio;
 
 pub fn run() {
-    let direnv = "direnv";
     let shell = Shell::from_env();
     let parent_pid = env::var("DIRENV_INSTANT_SHELL_PID")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or_else(|| getppid().as_raw());
+
+    if shell == Shell::Nushell {
+        nushell::run(parent_pid, find_envrc);
+        return;
+    }
+
+    let direnv = "direnv";
 
     // Find .envrc directory
     let envrc_dir = match find_envrc() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -238,7 +238,13 @@ fn run_direnv(direnv_cmd: &str, ctx: &DaemonContext) {
     let _cleanup = Cleanup(ctx);
 
     let listener = UnixListener::bind(&ctx.socket_path).expect("Failed to bind socket");
-    let notify_pids = Arc::new(Mutex::new(vec![ctx.parent_pid]));
+    // Nushell has no signal handler, so SIGUSR1 would terminate the shell;
+    // skip registering its pid for notification.
+    let notify_pids = Arc::new(Mutex::new(if ctx.shell == Shell::Nushell {
+        vec![]
+    } else {
+        vec![ctx.parent_pid]
+    }));
     let should_stop = Arc::new(AtomicBool::new(false));
     let pty_master: Arc<Mutex<Option<OwnedFd>>> = Arc::new(Mutex::new(None));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 mod daemon;
 mod mux;
+mod nushell;
 mod shell;
 
 use std::env;

--- a/src/nushell.rs
+++ b/src/nushell.rs
@@ -1,0 +1,135 @@
+//! Nushell entry point for `start`. The nu hook cannot react to SIGUSR1
+//! (no trap primitive) nor `source` dynamic command output (parse-time
+//! const path required), so the binary emits a single compact JSON
+//! record describing internal var changes and the hook applies it via
+//! `load-env` / `hide-env`. Direnv's own export goes to `env_file` as
+//! `direnv export json` so the hook can parse it directly.
+
+use crate::daemon::{
+    DaemonContext, direnv_export_command, get_runtime_dir, get_socket_path, start_daemon,
+    stop_daemon,
+};
+use crate::mux::Multiplexer;
+use crate::shell::Shell;
+use std::env;
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+pub fn run(parent_pid: i32, find_envrc: impl FnOnce() -> Option<PathBuf>) {
+    let direnv = "direnv";
+    let mut state: Vec<(&str, Option<String>)> = Vec::new();
+
+    let envrc_dir = match find_envrc() {
+        Some(dir) => dir,
+        None => {
+            state.push(("__DIRENV_INSTANT_CURRENT_DIR", None));
+            // direnv emits unset directives for previously-set vars; capture
+            // those to a per-pid file so the hook can apply them.
+            if let Some(p) = capture_direnv_export(direnv, false, None) {
+                state.push(("__DIRENV_INSTANT_ENV_FILE", Some(p.display().to_string())));
+            }
+            emit_record(&state);
+            return;
+        }
+    };
+
+    if let Ok(current) = env::var("__DIRENV_INSTANT_CURRENT_DIR") {
+        let cd = PathBuf::from(&current);
+        if cd != envrc_dir {
+            stop_daemon(&get_socket_path(&cd));
+        }
+    }
+    state.push((
+        "__DIRENV_INSTANT_CURRENT_DIR",
+        Some(envrc_dir.display().to_string()),
+    ));
+
+    if Multiplexer::detect().is_none() {
+        let runtime = get_runtime_dir(&envrc_dir);
+        let _ = std::fs::create_dir_all(&runtime);
+        let env_file = runtime.join("env");
+        if let Some(p) = capture_direnv_export(direnv, true, Some(&env_file)) {
+            state.push(("__DIRENV_INSTANT_ENV_FILE", Some(p.display().to_string())));
+        }
+        emit_record(&state);
+        return;
+    }
+
+    let ctx = match DaemonContext::new(parent_pid, envrc_dir, Shell::Nushell) {
+        Ok(ctx) => ctx,
+        Err(e) => {
+            eprintln!("direnv-instant: Failed to create temp files: {}", e);
+            emit_record(&state);
+            return;
+        }
+    };
+    state.push((
+        "__DIRENV_INSTANT_ENV_FILE",
+        Some(ctx.env_file.display().to_string()),
+    ));
+    state.push((
+        "__DIRENV_INSTANT_STDERR_FILE",
+        Some(ctx.stderr_file.display().to_string()),
+    ));
+
+    let already_running = ctx.socket_path.exists() && UnixStream::connect(&ctx.socket_path).is_ok();
+    emit_record(&state);
+    if !already_running {
+        start_daemon(direnv, &ctx);
+    }
+}
+
+fn emit_record(state: &[(&str, Option<String>)]) {
+    print!("{{");
+    for (i, (k, v)) in state.iter().enumerate() {
+        if i > 0 {
+            print!(",");
+        }
+        match v {
+            Some(s) => print!(r#""{}":"{}""#, json_escape(k), json_escape(s)),
+            None => print!(r#""{}":null"#, json_escape(k)),
+        }
+    }
+    println!("}}");
+}
+
+/// Run `direnv export json` and write its stdout to *target*, or to a
+/// per-pid temp file if None. Returns the file path on success.
+fn capture_direnv_export(
+    direnv: &str,
+    show_errors: bool,
+    target: Option<&Path>,
+) -> Option<PathBuf> {
+    let mut cmd = direnv_export_command(direnv, Shell::Nushell);
+    if !show_errors {
+        cmd.stderr(Stdio::null());
+    }
+    let out = cmd.output().ok()?;
+    if !out.status.success() || out.stdout.is_empty() {
+        return None;
+    }
+    let path = match target {
+        Some(p) => p.to_path_buf(),
+        None => std::env::temp_dir().join(format!("direnv-instant-nu-{}.json", std::process::id())),
+    };
+    std::fs::write(&path, &out.stdout).ok()?;
+    Some(path)
+}
+
+/// Minimal JSON string escape (no dep on serde_json).
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -6,6 +6,7 @@ pub enum Shell {
     Bash,
     Zsh,
     Fish,
+    Nushell,
 }
 
 impl Shell {
@@ -13,24 +14,29 @@ impl Shell {
         match env::var("DIRENV_INSTANT_SHELL").as_deref() {
             Ok("fish") => Shell::Fish,
             Ok("zsh") => Shell::Zsh,
+            Ok("nu" | "nushell") => Shell::Nushell,
             _ => Shell::Bash,
         }
     }
 
-    /// Returns the shell name for direnv export command
+    /// Shell name passed to `direnv export`. Nushell has no native format,
+    /// so we use json and let the hook parse it via `from json | load-env`.
     pub fn direnv_export_arg(self) -> &'static str {
         match self {
             Shell::Fish => "fish",
+            Shell::Nushell => "json",
             Shell::Bash | Shell::Zsh => "zsh",
         }
     }
 
-    /// Print an export statement for this shell
+    /// Print an export statement for this shell.
+    /// Nushell is handled separately in [`crate::nushell`]; calls here are unreachable.
     pub fn export_var(self, name: &str, value: &str) {
         let escaped = value.replace('\'', r"'\''");
         match self {
             Shell::Fish => println!("set -gx {} '{}'", name, escaped),
             Shell::Bash | Shell::Zsh => println!("export {}='{}'", name, escaped),
+            Shell::Nushell => unreachable!("nushell uses crate::nushell"),
         }
     }
 
@@ -39,6 +45,7 @@ impl Shell {
         match self {
             Shell::Fish => println!("set -e {}", name),
             Shell::Bash | Shell::Zsh => println!("unset {}", name),
+            Shell::Nushell => unreachable!("nushell uses crate::nushell"),
         }
     }
 }

--- a/tests.nix
+++ b/tests.nix
@@ -6,6 +6,7 @@
   direnv,
   tmux,
   fish,
+  nushell,
 }:
 
 let
@@ -28,6 +29,7 @@ runCommand "direnv-instant-tests"
       direnv
       tmux
       fish
+      nushell
     ];
 
     meta = with lib; {

--- a/tests/test_nushell_integration.py
+++ b/tests/test_nushell_integration.py
@@ -38,7 +38,18 @@ def test_nushell_apply_unset_reenter(
     allow_direnv(tmp_path, monkeypatch)
 
     binary_dir = Path(direnv_instant.binary_path).resolve().parent
-    hook_path = Path(__file__).resolve().parent.parent / "hooks" / "nushell.nu"
+    # Materialize the hook from the binary itself: nushell's `source` resolves
+    # at parse time and needs a real local path, and the source tree's hooks/
+    # dir isn't part of the test fileset in the Nix build sandbox.
+    hook_path = tmp_path / "nushell.nu"
+    hook_path.write_text(
+        subprocess.run(
+            [direnv_instant.binary_path, "hook", "nu"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    )
     script = tmp_path / "drive.nu"
     script.write_text(
         f"""$env.PATH = ([

--- a/tests/test_nushell_integration.py
+++ b/tests/test_nushell_integration.py
@@ -1,0 +1,88 @@
+"""Test direnv-instant integration with Nushell.
+
+Nushell has no signal-handler primitive, so the hook can't react to the
+daemon's SIGUSR1. It instead loads the env_file (direnv's `export json`
+output) at pre_prompt and pre_execution. This test exercises the sync
+no-mux path (which requires the JSON-emitting nushell mode in `start`)
+and verifies env apply, unset on leave, and re-apply on re-enter.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers import allow_direnv, setup_envrc
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+    from tests.conftest import DirenvInstantRunner
+
+
+NU = shutil.which("nu")
+pytestmark = pytest.mark.skipif(NU is None, reason="nushell not installed")
+
+
+def test_nushell_apply_unset_reenter(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    direnv_instant: DirenvInstantRunner,
+) -> None:
+    setup_envrc(tmp_path, "export NU_TEST_VAR=hello_from_direnv\n")
+    allow_direnv(tmp_path, monkeypatch)
+
+    binary_dir = Path(direnv_instant.binary_path).resolve().parent
+    hook_path = Path(__file__).resolve().parent.parent / "hooks" / "nushell.nu"
+    script = tmp_path / "drive.nu"
+    script.write_text(
+        f"""$env.PATH = ([
+    "{binary_dir}"
+    (which direnv | get path | first | path dirname)
+] | append ($env.PATH | split row (char esep)))
+source {hook_path}
+
+cd {tmp_path}
+_direnv_instant_hook
+print $"enter=($env.NU_TEST_VAR? | default '<unset>')"
+
+cd /
+_direnv_instant_hook
+print $"leave=($env.NU_TEST_VAR? | default '<unset>')"
+
+cd {tmp_path}
+_direnv_instant_hook
+print $"reenter=($env.NU_TEST_VAR? | default '<unset>')"
+"""
+    )
+
+    # Minimal env: avoid inheriting parent direnv/multiplexer state that
+    # would make `direnv export json` emit unsets for the parent env (and
+    # in particular clobber PATH on apply).
+    env = {
+        "HOME": os.environ["HOME"],
+        "PATH": os.environ["PATH"],
+        "XDG_DATA_HOME": os.environ.get(
+            "XDG_DATA_HOME", str(Path(os.environ["HOME"]) / ".local/share")
+        ),
+    }
+    result = subprocess.run(
+        [NU, str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"nu exited {result.returncode}\n"
+        f"--stdout--\n{result.stdout}\n--stderr--\n{result.stderr}"
+    )
+    out = result.stdout
+    assert "enter=hello_from_direnv" in out, out
+    assert "leave=<unset>" in out, out
+    assert "reenter=hello_from_direnv" in out, out


### PR DESCRIPTION
Nushell has no signal-trap and no way to source dynamic command output (`source` is parse-time, const path required), so its hook can't react to SIGUSR1 like bash/zsh/fish. The hook runs at pre_prompt and pre_execution, parses a JSON record from `direnv-instant start`, and applies updates via load-env / hide-env. `direnv export json` is written verbatim to env_file (null = unset, matching direnv's semantics).

The hook merges cached env, the start record, and the freshly-written env_file into one record before applying, working around a nushell quirk where hide-env after load-env across `--env` def boundaries does not propagate. Pre_prompt + pre_execution gives correctness parity with the SIGUSR1 path: the prompt may render once with stale env, but the user's command always runs with current env.