### PR TITLE
fix: stop clobbering user env on every prompt (#88)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
                 clippy
                 rust-analyzer
                 fish
+                zsh
               ];
             };
 

--- a/hooks/bash.sh
+++ b/hooks/bash.sh
@@ -23,15 +23,15 @@ _direnv_handler() {
   fi
 }
 
-# Main hook called on directory changes and prompts
+# Main hook called on directory changes and prompts.
+#
+# Note: we deliberately do NOT eval the cached env_file on every prompt.
+# Doing so re-applies `export PATH='<original>'` and clobbers user-added
+# entries (e.g. from `nix shell`). The binary now emits cached env once
+# per dir change (or runs `direnv export` for a delta when envrc is
+# already loaded), and the SIGUSR1 trap handles async daemon completion.
 _direnv_hook() {
   export DIRENV_INSTANT_SHELL_PID=$$
-
-  # Load cached environment immediately if available and caching is enabled
-  if [[ ${DIRENV_INSTANT_USE_CACHE:-1} == 1 ]] && [[ -n $__DIRENV_INSTANT_ENV_FILE ]] && [[ -f $__DIRENV_INSTANT_ENV_FILE ]]; then
-    eval "$(<"$__DIRENV_INSTANT_ENV_FILE")"
-  fi
-
   local previous_exit_status=$?;
   trap -- '' SIGINT;
   eval "$(direnv-instant start)"

--- a/hooks/fish.fish
+++ b/hooks/fish.fish
@@ -22,16 +22,16 @@ function _direnv_handler --on-signal USR1
     end
 end
 
-# Main hook called on directory changes and prompts
+# Main hook called on directory changes and prompts.
+#
+# Note: we deliberately do NOT source the cached env_file on every prompt.
+# Doing so re-applies `set -gx PATH '<original>'` and clobbers user-added
+# entries (e.g. from `nix shell`). The binary now emits cached env once
+# per dir change (or runs `direnv export` for a delta when envrc is
+# already loaded), and the SIGUSR1 handler handles async daemon completion.
 function _direnv_hook --on-event fish_prompt --on-variable PWD
     set -gx DIRENV_INSTANT_SHELL fish
     set -gx DIRENV_INSTANT_SHELL_PID $fish_pid
-
-    # Load cached environment immediately if available and caching is enabled
-    if test "$DIRENV_INSTANT_USE_CACHE" != 0 -a -n "$__DIRENV_INSTANT_ENV_FILE" -a -f "$__DIRENV_INSTANT_ENV_FILE"
-        source "$__DIRENV_INSTANT_ENV_FILE"
-    end
-
     direnv-instant start | source
 end
 

--- a/hooks/zsh.sh
+++ b/hooks/zsh.sh
@@ -40,15 +40,15 @@ TRAPUSR1() {
   zle && zle .reset-prompt && zle -R
 }
 
-# Main hook called on directory changes and prompts
+# Main hook called on directory changes and prompts.
+#
+# Note: we deliberately do NOT eval the cached env_file on every prompt.
+# Doing so re-applies `export PATH='<original>'` and clobbers user-added
+# entries (e.g. from `nix shell`). The binary now emits cached env once
+# per dir change (or runs `direnv export` for a delta when envrc is
+# already loaded), and the SIGUSR1 trap handles async daemon completion.
 _direnv_hook() {
   export DIRENV_INSTANT_SHELL_PID=$$
-
-  # Load cached environment immediately if available and caching is enabled
-  if [[ ${DIRENV_INSTANT_USE_CACHE:-1} == 1 ]] && [[ -n $__DIRENV_INSTANT_ENV_FILE ]] && [[ -f $__DIRENV_INSTANT_ENV_FILE ]]; then
-    eval "$(<"$__DIRENV_INSTANT_ENV_FILE")"
-  fi
-
   trap -- '' SIGINT
   eval "$(direnv-instant start)"
   trap - SIGINT

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -6,7 +6,7 @@ use crate::shell::Shell;
 use nix::unistd::getppid;
 use std::env;
 use std::os::unix::process::CommandExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 pub fn run() {
@@ -27,13 +27,34 @@ pub fn run() {
         }
     };
 
-    // Check if we need to restart daemon (different directory)
-    if let Ok(current) = env::var("__DIRENV_INSTANT_CURRENT_DIR") {
-        let current_dir = PathBuf::from(&current);
-        if current_dir != envrc_dir {
-            stop_daemon(&get_socket_path(&current_dir));
-        }
+    // Steady-state fast path: envrc is already loaded into the current shell
+    // (DIRENV_DIR matches and __DIRENV_INSTANT_CURRENT_DIR is unchanged), so
+    // delegate to `direnv export` directly. It emits only the delta needed
+    // and preserves user PATH additions (e.g. from `nix shell`) instead of
+    // re-applying the cached snapshot wholesale (issue #88).
+    if envrc_already_loaded(&envrc_dir)
+        && env::var("__DIRENV_INSTANT_CURRENT_DIR").as_deref()
+            == Ok(&envrc_dir.display().to_string())
+    {
+        run_direnv_sync(direnv, shell, true);
+        return;
     }
+
+    // Check if we changed dirs since the last hook fire. The cache emit
+    // below is gated on this so the user's mid-prompt env mutations aren't
+    // clobbered on every prompt (issue #88).
+    let dir_changed = match env::var("__DIRENV_INSTANT_CURRENT_DIR") {
+        Ok(current) => {
+            let current_dir = PathBuf::from(&current);
+            if current_dir != envrc_dir {
+                stop_daemon(&get_socket_path(&current_dir));
+                true
+            } else {
+                false
+            }
+        }
+        Err(_) => true,
+    };
     shell.export_var(
         "__DIRENV_INSTANT_CURRENT_DIR",
         &envrc_dir.display().to_string(),
@@ -63,12 +84,34 @@ pub fn run() {
         &ctx.stderr_file.display().to_string(),
     );
 
+    // Cold-start UX: when entering this dir, emit the cached env_file once
+    // so the prompt sees the env immediately. Subsequent prompts in the
+    // same dir skip this so user-added env vars aren't clobbered. The
+    // daemon will refresh asynchronously and SIGUSR1 the shell when it has
+    // fresh output.
+    if dir_changed
+        && ctx.env_file.exists()
+        && let Ok(content) = std::fs::read_to_string(&ctx.env_file)
+    {
+        print!("{}", content);
+    }
+
     // Check if daemon is already running
     if ctx.socket_path.exists() && notify_daemon(&ctx.socket_path, parent_pid) {
         return;
     }
 
     start_daemon(direnv, &ctx);
+}
+
+/// True if the current shell already has *envrc_dir* loaded by direnv (i.e.
+/// `DIRENV_DIR == "-<envrc_dir>"`, the format direnv uses internally).
+fn envrc_already_loaded(envrc_dir: &Path) -> bool {
+    let Ok(direnv_dir) = env::var("DIRENV_DIR") else {
+        return false;
+    };
+    let stripped = direnv_dir.strip_prefix('-').unwrap_or(&direnv_dir);
+    Path::new(stripped) == envrc_dir
 }
 
 fn find_envrc() -> Option<PathBuf> {

--- a/tests.nix
+++ b/tests.nix
@@ -6,6 +6,7 @@
   direnv,
   tmux,
   fish,
+  zsh,
 }:
 
 let
@@ -28,6 +29,7 @@ runCommand "direnv-instant-tests"
       direnv
       tmux
       fish
+      zsh
     ];
 
     meta = with lib; {

--- a/tests/test_user_path_addition_survives.py
+++ b/tests/test_user_path_addition_survives.py
@@ -1,0 +1,93 @@
+"""Regression test for #88: user PATH additions must survive subsequent prompts.
+
+Reproduction:
+- Enter an envrc dir (direnv-instant loads envrc).
+- User runs `export PATH=/userdir:$PATH` (mimicking `nix shell`'s effect).
+- Next prompt fires the precmd hook.
+- /userdir must still be on PATH afterwards.
+
+Pre-fix the hook re-eval'd the cached env_file every prompt, which contains
+`export PATH='<original>'` and clobbered /userdir. Now we delegate to
+`direnv export` directly when the envrc is already loaded — direnv emits
+only the delta and leaves user additions alone.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.helpers import allow_direnv, setup_envrc
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+    from tests.conftest import DirenvInstantRunner
+
+
+ZSH = shutil.which("zsh")
+pytestmark = pytest.mark.skipif(ZSH is None, reason="zsh not installed")
+
+
+def test_user_path_addition_survives_next_prompt(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    direnv_instant: DirenvInstantRunner,
+) -> None:
+    setup_envrc(tmp_path, "PATH_add /tmp/dir-from-envrc\nexport FROM_ENVRC=1\n")
+    allow_direnv(tmp_path, monkeypatch)
+
+    binary_dir = Path(direnv_instant.binary_path).resolve().parent
+    user_dir = tmp_path / "user-bin"
+    user_dir.mkdir()
+
+    # Bug only manifests in multiplexer/daemon mode (the cached env_file
+    # lives there); fake a TMUX session to take that code path.
+    fake_tmux_state = tmp_path / "fake-tmux"
+    fake_tmux_state.touch()
+
+    # Each line in the script triggers a precmd cycle in `zsh -i < script`.
+    # Between the user's `export PATH=...` line and the inspection line,
+    # precmd fires `_direnv_hook`. The MARKER must contain user_dir.
+    script = tmp_path / "drive.zsh"
+    script.write_text(
+        f'eval "$(direnv-instant hook zsh)"\n'
+        f"export PATH={user_dir}:$PATH\n"
+        f'echo "MARKER=$PATH"\n'
+    )
+
+    env = {
+        "HOME": os.environ["HOME"],
+        "PATH": f"{binary_dir}:{os.environ['PATH']}",
+        "XDG_DATA_HOME": os.environ.get(
+            "XDG_DATA_HOME", str(Path(os.environ["HOME"]) / ".local/share")
+        ),
+        "TMUX": f"{fake_tmux_state},0,0",
+        "DIRENV_INSTANT_MUX_DELAY": "60000",
+    }
+    result = subprocess.run(
+        [ZSH, "-i"],
+        check=False,
+        input=script.read_text(),
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+    )
+
+    # zsh -i decorates output with terminal escape sequences; locate the
+    # MARKER substring anywhere in the joined stdout.
+    idx = result.stdout.find("MARKER=")
+    assert idx != -1, (
+        f"MARKER not found in stdout:\n{result.stdout}\n--stderr--\n{result.stderr}"
+    )
+    marker = result.stdout[idx : idx + 4096].splitlines()[0]
+    assert str(user_dir) in marker, (
+        f"User PATH addition was clobbered by precmd re-eval (issue #88).\n"
+        f"Got: {marker}"
+    )


### PR DESCRIPTION
fix: stop clobbering user env on every prompt (#88)

The bash/zsh/fish hooks unconditionally re-eval'd the cached env_file
on every prompt. That file is the full `direnv export <shell>`
output captured at envrc load time and contains absolute
`export PATH='<original>'` lines, so every prompt silently undid
user-added PATH entries \u2014 including the additions a nested
`nix shell nixpkgs#hello` makes from inside an already-loaded direnv
envrc.

Standard direnv avoids this because its hook re-runs `direnv export`
on every prompt and direnv emits only the *delta* needed; user
additions look already-correct so no diff is emitted. Mirror that:
drop the per-prompt cache-eval from all three POSIX hooks, and in
`commands::start` take a fast path when the envrc is already loaded
(`DIRENV_DIR` matches) by execing `direnv export <shell>` directly.
The cold-start cache emit is kept for dir-change so the prompt still
gets instant env on entering a known dir; the SIGUSR1 trap still
applies the daemon's fresh output when it lands.

