### PR TITLE
feat(home-manager): add enableNushellIntegration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Non-blocking direnv integration daemon with tmux/zellij support that provides in
 - **Environment Caching**: Uses cached environment from previous load for truly instant prompts
 - **Asynchronous Loading**: Direnv runs in the background, shell gets notified when ready via SIGUSR1
 - **Multiplexer Integration**: Automatically spawns a tmux/zellij pane to show direnv output when loading takes too long
-- **Shell Support**: Works with bash, zsh, and fish
+- **Shell Support**: Works with bash, zsh, fish, and nushell
 
 ## How It Works
 
@@ -155,6 +155,19 @@ Add to your `~/.config/fish/config.fish`:
 direnv-instant hook fish | source
 ```
 
+### Nushell
+
+Nushell's `source` is resolved at parse time and cannot evaluate command
+output, so there is no `direnv-instant hook nu | source` one-liner. Use the
+Home Manager module (`programs.direnv-instant.enableNushellIntegration`),
+which sources the hook file shipped at
+`$out/share/direnv-instant/nushell.nu`.
+
+> **Note:** Nushell has no signal-trap mechanism, so the hook cannot react to
+> the daemon's SIGUSR1 like the other shells. It instead reloads the cached env
+> file on each prompt and before each command, so the environment appears once
+> direnv finishes — typically by the next prompt.
+
 ## Configuration
 
 ### Module Options
@@ -178,6 +191,7 @@ The Home Manager module additionally supports:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enableKittyIntegration` | bool | `config.programs.kitty.enable` | Enable Kitty terminal integration |
+| `enableNushellIntegration` | bool | `true` | Enable Nushell integration |
 
 ### Environment Variables
 

--- a/default.nix
+++ b/default.nix
@@ -21,6 +21,12 @@ rustPlatform.buildRustPackage {
     lockFile = ./Cargo.lock;
   };
 
+  # Nushell's `source` is a parse-time keyword and cannot read command
+  # output, so ship the hook as a file users can source by path.
+  postInstall = ''
+    install -Dm644 hooks/nushell.nu $out/share/direnv-instant/nushell.nu
+  '';
+
   meta = with lib; {
     description = "Non-blocking direnv integration daemon with tmux support";
     license = licenses.mit;

--- a/home.nix
+++ b/home.nix
@@ -18,6 +18,7 @@ let
   inherit (lib.hm.shell)
     mkBashIntegrationOption
     mkFishIntegrationOption
+    mkNushellIntegrationOption
     mkZshIntegrationOption
     ;
 
@@ -53,6 +54,7 @@ in
 
     enableBashIntegration = mkBashIntegrationOption { inherit config; };
     enableFishIntegration = mkFishIntegrationOption { inherit config; };
+    enableNushellIntegration = mkNushellIntegrationOption { inherit config; };
     enableZshIntegration = mkZshIntegrationOption { inherit config; };
 
     enableKittyIntegration = (mkEnableOption "kitty integration") // {
@@ -120,6 +122,7 @@ in
         # direnv and direnv-instant have mutually exclusive hooks
         enableBashIntegration = lib.mkIf cfg.enableBashIntegration (lib.mkForce false);
         enableZshIntegration = lib.mkIf cfg.enableZshIntegration (lib.mkForce false);
+        enableNushellIntegration = lib.mkIf cfg.enableNushellIntegration (lib.mkForce false);
       }
       // lib.optionalAttrs (!fishIntegrationReadOnly) {
         # Only disable fish integration if the option is not read-only (unstable home-manager)
@@ -139,6 +142,12 @@ in
 
       programs.fish.interactiveShellInit = mkIf cfg.enableFishIntegration ''
         direnv-instant hook fish | source
+      '';
+
+      # Nushell's `source` resolves at parse time and cannot evaluate command
+      # output, so source the hook file shipped in the package.
+      programs.nushell.extraConfig = mkIf cfg.enableNushellIntegration ''
+        source ${cfg.package}/share/direnv-instant/nushell.nu
       '';
 
       programs.kitty.settings = mkIf cfg.enableKittyIntegration {


### PR DESCRIPTION
Nushell's `source` is a parse-time keyword and cannot consume command
output, so there is no `hook nu | source` one-liner like the other
shells. Ship the hook file at $out/share/direnv-instant/nushell.nu and
have the Home Manager module source it directly; that is the only
supported setup path documented in the README.

Also force-disable programs.direnv.enableNushellIntegration so both
hooks don't run, mirroring the existing bash/zsh handling.

The NixOS module is left alone: nixpkgs has no programs.nushell module
to attach the hook to.