### PR TITLE
flake: bump nixpkgs and drop x86_64-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,6 @@
         systems = [
           "x86_64-linux"
           "aarch64-linux"
-          "x86_64-darwin"
           "aarch64-darwin"
         ];
 

--- a/hooks/nushell.nu
+++ b/hooks/nushell.nu
@@ -15,11 +15,12 @@ def _direnv_instant_load_file [path: string]: nothing -> record {
 }
 
 def --env _direnv_instant_apply [data: record] {
+    let entries = ($data | transpose key val)
     let to_load = (
-        $data | items {|k v| {key: $k, val: $v} } | where val != null
+        $entries | where val != null
         | reduce -f {} {|it acc| $acc | upsert $it.key $it.val }
     )
-    let to_unset = ($data | items {|k v| if $v == null { $k } } | compact)
+    let to_unset = ($entries | where val == null | get key)
     for k in $to_unset { hide-env --ignore-errors $k }
     if not ($to_load | is-empty) { load-env $to_load }
 }


### PR DESCRIPTION

nixpkgs no longer supports x86_64-darwin, so remove it from the
supported systems list to avoid broken evaluation.
