### PR TITLE
start: only create temp files inside the daemon process

### DIFF
--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -56,7 +56,7 @@ pub fn run() {
     let ctx = match DaemonContext::new(parent_pid, envrc_dir, shell) {
         Ok(ctx) => ctx,
         Err(e) => {
-            eprintln!("direnv-instant: Failed to create temp files: {}", e);
+            eprintln!("direnv-instant: Failed to create runtime dir: {}", e);
             run_direnv_sync(direnv, shell, true);
             return;
         }
@@ -75,7 +75,7 @@ pub fn run() {
         return;
     }
 
-    start_daemon(direnv, &ctx);
+    start_daemon(direnv, ctx);
 }
 
 fn find_envrc() -> Option<PathBuf> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -73,6 +73,7 @@ fn create_temp_file(runtime_dir: &Path, prefix: &str) -> std::io::Result<PathBuf
 
 pub struct DaemonContext {
     pub parent_pid: i32,
+    pub runtime_dir: PathBuf,
     pub socket_path: PathBuf,
     pub env_file: PathBuf,
     pub stderr_file: PathBuf,
@@ -91,19 +92,25 @@ impl DaemonContext {
         // Ensure owner-only permissions even if directory already exists
         std::fs::set_permissions(&runtime_dir, PermissionsExt::from_mode(0o700))?;
 
-        let temp_file = create_temp_file(&runtime_dir, "env")?;
-        let temp_stderr = create_temp_file(&runtime_dir, "env_stderr")?;
-
         Ok(Self {
             parent_pid,
             socket_path: runtime_dir.join("daemon.sock"),
             env_file: runtime_dir.join("env"),
             stderr_file: runtime_dir.join("env.stderr"),
-            temp_file,
-            temp_stderr,
+            // Filled in by create_temp_files() in the daemon process, so
+            // per-prompt "already running" starts don't leak temp files.
+            temp_file: PathBuf::new(),
+            temp_stderr: PathBuf::new(),
+            runtime_dir,
             multiplexer: Multiplexer::detect(),
             shell,
         })
+    }
+
+    fn create_temp_files(&mut self) -> std::io::Result<()> {
+        self.temp_file = create_temp_file(&self.runtime_dir, "env")?;
+        self.temp_stderr = create_temp_file(&self.runtime_dir, "env_stderr")?;
+        Ok(())
     }
 }
 
@@ -130,7 +137,7 @@ pub fn stop_daemon(socket_path: &Path) {
     let _ = send_daemon_message(socket_path, "STOP\n");
 }
 
-pub fn start_daemon(direnv_cmd: &str, ctx: &DaemonContext) {
+pub fn start_daemon(direnv_cmd: &str, mut ctx: DaemonContext) {
     // Check if daemon already running
     if ctx.socket_path.exists() {
         if UnixStream::connect(&ctx.socket_path).is_ok() {
@@ -164,7 +171,7 @@ pub fn start_daemon(direnv_cmd: &str, ctx: &DaemonContext) {
                         dup2_stderr(&devnull).expect("Failed to redirect stderr");
                     }
 
-                    run_direnv(direnv_cmd, ctx);
+                    run_direnv(direnv_cmd, &mut ctx);
                 }
                 Err(e) => {
                     eprintln!("direnv-instant: Second fork failed: {}", e);
@@ -234,7 +241,11 @@ fn handle_socket_commands(
     }
 }
 
-fn run_direnv(direnv_cmd: &str, ctx: &DaemonContext) {
+fn run_direnv(direnv_cmd: &str, ctx: &mut DaemonContext) {
+    if let Err(e) = ctx.create_temp_files() {
+        eprintln!("direnv-instant: Failed to create temp files: {}", e);
+        std::process::exit(1);
+    }
     let _cleanup = Cleanup(ctx);
 
     let listener = UnixListener::bind(&ctx.socket_path).expect("Failed to bind socket");

--- a/src/nushell.rs
+++ b/src/nushell.rs
@@ -59,7 +59,7 @@ pub fn run(parent_pid: i32, find_envrc: impl FnOnce() -> Option<PathBuf>) {
     let ctx = match DaemonContext::new(parent_pid, envrc_dir, Shell::Nushell) {
         Ok(ctx) => ctx,
         Err(e) => {
-            eprintln!("direnv-instant: Failed to create temp files: {}", e);
+            eprintln!("direnv-instant: Failed to create runtime dir: {}", e);
             emit_record(&state);
             return;
         }
@@ -76,7 +76,7 @@ pub fn run(parent_pid: i32, find_envrc: impl FnOnce() -> Option<PathBuf>) {
     let already_running = ctx.socket_path.exists() && UnixStream::connect(&ctx.socket_path).is_ok();
     emit_record(&state);
     if !already_running {
-        start_daemon(direnv, &ctx);
+        start_daemon(direnv, ctx);
     }
 }
 

--- a/tests/no_temp_leak_when_daemon_running.rs
+++ b/tests/no_temp_leak_when_daemon_running.rs
@@ -1,0 +1,75 @@
+//! Repeated `start` invocations while a daemon is already evaluating a slow
+//! `.envrc` must not leak env.XXXXXX / env_stderr.XXXXXX temp files into the
+//! runtime directory (regression test for issue #128).
+
+mod common;
+use common::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+fn temp_file_count(runtime_dir: &Path) -> usize {
+    fs::read_dir(runtime_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            (name.starts_with("env.") && name != "env.stderr") || name.starts_with("env_stderr.")
+        })
+        .count()
+}
+
+#[test]
+fn no_temp_leak_when_daemon_running() {
+    require!("tmux");
+    let sb = Sandbox::new("sleep 3600\n").unwrap();
+    let server = TmuxServer::new(&sb.dir).unwrap();
+    let sink = SignalSink::new().unwrap();
+    let env = sb.tmux_env(&server, sink.pid());
+
+    let out = sb.run(&["start"], &env).unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let exports = parse_exports(&String::from_utf8_lossy(&out.stdout));
+    let runtime_dir = PathBuf::from(&exports["__DIRENV_INSTANT_STDERR_FILE"])
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let socket_path = runtime_dir.join("daemon.sock");
+
+    // Wait until the daemon is up so subsequent starts hit the notify path.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while !socket_path.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "daemon socket never appeared"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let baseline = temp_file_count(&runtime_dir);
+
+    // Simulate additional shell prompts while the evaluation is still running.
+    for _ in 0..3 {
+        let out = sb.run(&["start"], &env).unwrap();
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    let after = temp_file_count(&runtime_dir);
+    assert_eq!(
+        after, baseline,
+        "temp files leaked into runtime dir: {baseline} -> {after}"
+    );
+
+    // Cleanup: stop the daemon.
+    let _ = sb.run(&["stop"], &env);
+    let _ = wait_for_daemon_exit(&socket_path, Duration::from_secs(5));
+}


### PR DESCRIPTION

DaemonContext::new() unconditionally mkstemp'd env.XXXXXX and
env_stderr.XXXXXX before checking whether a daemon was already running.
Since the shell hooks run 'direnv-instant start' on every prompt, each
prompt during a long evaluation leaked two empty files into the runtime
directory (and thus ~/.cache) that were never cleaned up.

Defer temp file creation to run_direnv(), which only executes in the
process that actually becomes the daemon and already removes them via
the Cleanup guard. The per-prompt notify path no longer touches disk.

Fixes #128
