### PR TITLE
fish: unregister direnv's classic hook loaded from vendor conf.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ fish (`~/.config/fish/config.fish`):
 direnv-instant hook fish | source
 ```
 
+fish note: the nix direnv package ships `share/fish/vendor_conf.d/direnv.fish`,
+which fish auto-loads even though no hook line appears in your config. The
+direnv-instant hook unregisters those handlers, so the `config.fish` line above
+is enough.
+
 nushell: there's no `hook nu | source` one-liner because nushell's `source` is
 parse-time only. The hook ships at `share/direnv-instant/nushell.nu`; the
 home-manager module sources it for you when

--- a/hooks/fish.fish
+++ b/hooks/fish.fish
@@ -1,6 +1,10 @@
 # direnv-instant.fish - Non-blocking direnv integration for fish
 # Provides instant prompts by running direnv asynchronously in the background
 
+# direnv's classic hook may auto-load from a vendor_conf.d file (e.g. the nix
+# package) and would block every prompt alongside us; unregister it.
+functions -e __direnv_export_eval __direnv_export_eval_2 __direnv_cd_hook
+
 # Global state variables
 set -g __DIRENV_INSTANT_ENV_FILE ""
 set -g __DIRENV_INSTANT_STDERR_FILE ""


### PR DESCRIPTION

When direnv is installed via nix, its package ships
share/fish/vendor_conf.d/direnv.fish, which fish auto-loads whenever
~/.nix-profile/share is on XDG_DATA_DIRS. The classic blocking hook then
runs alongside direnv-instant, spawning a synchronous 'direnv export
fish' on every prompt that races the daemon's evaluation and blocks the
shell. Users can't fix this by removing hook lines because there are
none in their config.

Erase the classic handlers when the direnv-instant hook loads (user
config.fish is sourced after vendor conf.d), and document the vendor
conf.d pitfall in the README's manual setup section.

Fixes #127
