### PR TITLE
start: don't panic on EPIPE when writing shell exports to stdout

### DIFF
--- a/src/nushell.rs
+++ b/src/nushell.rs
@@ -81,17 +81,20 @@ pub fn run(parent_pid: i32, find_envrc: impl FnOnce() -> Option<PathBuf>) {
 }
 
 fn emit_record(state: &[(&str, Option<String>)]) {
-    print!("{{");
+    use std::fmt::Write;
+
+    let mut record = String::from("{");
     for (i, (k, v)) in state.iter().enumerate() {
         if i > 0 {
-            print!(",");
+            record.push(',');
         }
-        match v {
-            Some(s) => print!(r#""{}":"{}""#, json_escape(k), json_escape(s)),
-            None => print!(r#""{}":null"#, json_escape(k)),
-        }
+        let _ = match v {
+            Some(s) => write!(record, r#""{}":"{}""#, json_escape(k), json_escape(s)),
+            None => write!(record, r#""{}":null"#, json_escape(k)),
+        };
     }
-    println!("}}");
+    record.push('}');
+    crate::shell::emit(format_args!("{}", record));
 }
 
 /// Run `direnv export json` and write its stdout to *target*, or to a

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1,4 +1,12 @@
 use std::env;
+use std::io::Write;
+
+/// Write a line to stdout, ignoring errors. The hook reads our output via
+/// `start | source`; if the reader vanishes (ctrl-c, closed pane) the write
+/// fails with EPIPE, which is harmless and must not panic (issue #129).
+pub fn emit(args: std::fmt::Arguments) {
+    let _ = writeln!(std::io::stdout(), "{}", args);
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Shell {
@@ -34,8 +42,8 @@ impl Shell {
     pub fn export_var(self, name: &str, value: &str) {
         let escaped = value.replace('\'', r"'\''");
         match self {
-            Shell::Fish => println!("set -gx {} '{}'", name, escaped),
-            Shell::Bash | Shell::Zsh => println!("export {}='{}'", name, escaped),
+            Shell::Fish => emit(format_args!("set -gx {} '{}'", name, escaped)),
+            Shell::Bash | Shell::Zsh => emit(format_args!("export {}='{}'", name, escaped)),
             Shell::Nushell => unreachable!("nushell uses crate::nushell"),
         }
     }
@@ -43,8 +51,8 @@ impl Shell {
     /// Print an unset statement for this shell
     pub fn unset_var(self, name: &str) {
         match self {
-            Shell::Fish => println!("set -e {}", name),
-            Shell::Bash | Shell::Zsh => println!("unset {}", name),
+            Shell::Fish => emit(format_args!("set -e {}", name)),
+            Shell::Bash | Shell::Zsh => emit(format_args!("unset {}", name)),
             Shell::Nushell => unreachable!("nushell uses crate::nushell"),
         }
     }

--- a/tests/broken_pipe_on_start.rs
+++ b/tests/broken_pipe_on_start.rs
@@ -1,0 +1,33 @@
+// Regression test for https://github.com/Mic92/direnv-instant/issues/129:
+// `direnv-instant start` must not panic with "Broken pipe" when the reader
+// of its stdout (the shell hook's `source` pipeline) goes away early.
+
+mod common;
+
+use std::process::Command;
+
+#[test]
+fn start_does_not_panic_when_stdout_reader_closes_early() {
+    let sb = common::Sandbox::new("export FOO=bar").unwrap();
+    let env = sb.base_env();
+
+    // `head -c 0` closes the read end immediately, so every write to stdout
+    // from `start` hits EPIPE.
+    let out = Command::new("bash")
+        .arg("-c")
+        .arg(format!("'{}' start | head -c 0", common::bin().display()))
+        .current_dir(&sb.dir)
+        .env_clear()
+        .envs(&env)
+        .env("DIRENV_INSTANT_SHELL", "fish")
+        .env("DIRENV_INSTANT_SHELL_PID", std::process::id().to_string())
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "start panicked on broken pipe:\n{}",
+        stderr
+    );
+}


### PR DESCRIPTION

The shell hook consumes 'direnv-instant start' output via a pipe
(start | source). If the reader disappears mid-write - e.g. ctrl-c
during the prompt hook or a pane closing right after cd - println!
turns EPIPE into a panic:

    thread 'main' panicked at library/std/src/io/stdio.rs:
    failed printing to stdout: Broken pipe (os error 32)

The failure is harmless (the process was about to exit and the daemon
is already forked), so route hook-facing writes through an emit()
helper that ignores write errors. This keeps SIGPIPE handling and the
daemon's socket write semantics unchanged, unlike resetting SIGPIPE to
SIG_DFL globally.

Fixes https://github.com/Mic92/direnv-instant/issues/129
