### PR TITLE
stop: only shut down the daemon when the last registered shell detaches

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -2,7 +2,6 @@
   pkgs,
   lib,
   config,
-  options,
   ...
 }:
 let
@@ -29,12 +28,6 @@ let
     package
     str
     ;
-
-  # On stable home-manager (<= 24.11), enableFishIntegration is read-only
-  # because direnv ships fish vendor functions that auto-load.
-  # On unstable home-manager, this was fixed and we can disable it.
-  # See: https://github.com/Mic92/direnv-instant/issues/35
-  fishIntegrationReadOnly = options.programs.direnv.enableFishIntegration.readOnly or false;
 in
 {
   options.programs.direnv-instant = {
@@ -123,10 +116,6 @@ in
         enableBashIntegration = lib.mkIf cfg.enableBashIntegration (lib.mkForce false);
         enableZshIntegration = lib.mkIf cfg.enableZshIntegration (lib.mkForce false);
         enableNushellIntegration = lib.mkIf cfg.enableNushellIntegration (lib.mkForce false);
-      }
-      // lib.optionalAttrs (!fishIntegrationReadOnly) {
-        # Only disable fish integration if the option is not read-only (unstable home-manager)
-        # On stable home-manager (<= 25.11), both direnv and direnv-instant hooks run for fish.
         enableFishIntegration = lib.mkIf cfg.enableFishIntegration (lib.mkForce false);
       };
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,5 +1,6 @@
 use crate::daemon::{
-    DaemonContext, direnv_export_command, get_socket_path, notify_daemon, start_daemon, stop_daemon,
+    DaemonContext, detach_daemon, direnv_export_command, get_socket_path, notify_daemon,
+    start_daemon,
 };
 use crate::mux::Multiplexer;
 use crate::nushell;
@@ -38,7 +39,9 @@ pub fn run() {
     if let Ok(current) = env::var("__DIRENV_INSTANT_CURRENT_DIR") {
         let current_dir = PathBuf::from(&current);
         if current_dir != envrc_dir {
-            stop_daemon(&get_socket_path(&current_dir));
+            // Detach rather than force-stop: other shells in the old
+            // directory may still be waiting on that daemon.
+            detach_daemon(&get_socket_path(&current_dir), parent_pid);
         }
     }
     shell.export_var(

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -1,10 +1,16 @@
-use crate::daemon::{get_socket_path, stop_daemon};
+use crate::daemon::{detach_daemon, get_socket_path};
+use nix::unistd::getppid;
 use std::env;
 use std::path::PathBuf;
 
 pub fn run() {
+    let shell_pid = env::var("DIRENV_INSTANT_SHELL_PID")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| getppid().as_raw());
+
     if let Ok(dir) = env::var("__DIRENV_INSTANT_CURRENT_DIR") {
         let socket_path = get_socket_path(&PathBuf::from(dir));
-        stop_daemon(&socket_path);
+        detach_daemon(&socket_path, shell_pid);
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -133,8 +133,16 @@ pub fn notify_daemon(socket_path: &Path, shell_pid: i32) -> bool {
     send_daemon_message(socket_path, &format!("NOTIFY {shell_pid}\n")).is_ok()
 }
 
+/// Force the daemon to stop, regardless of which shells are registered.
 pub fn stop_daemon(socket_path: &Path) {
     let _ = send_daemon_message(socket_path, "STOP\n");
+}
+
+/// Detach one shell from the daemon. The daemon only stops once no
+/// registered shells remain, so one shell exiting doesn't kill an
+/// evaluation other shells still wait on (issue #130).
+pub fn detach_daemon(socket_path: &Path, shell_pid: i32) {
+    let _ = send_daemon_message(socket_path, &format!("STOP {shell_pid}\n"));
 }
 
 pub fn start_daemon(direnv_cmd: &str, mut ctx: DaemonContext) {
@@ -204,7 +212,23 @@ fn handle_socket_commands(
         if reader.read_line(&mut line).is_ok() {
             if let Some(stripped) = line.strip_prefix("NOTIFY ") {
                 if let Ok(pid) = stripped.trim().parse::<i32>() {
-                    notify_pids.lock().expect("Failed to lock").push(pid);
+                    let mut pids = notify_pids.lock().expect("Failed to lock");
+                    if !pids.contains(&pid) {
+                        pids.push(pid);
+                    }
+                }
+            } else if let Some(stripped) = line.strip_prefix("STOP ") {
+                // Pid-scoped stop: ignore pids we never registered, shut
+                // down when the last registered shell detaches.
+                if let Ok(pid) = stripped.trim().parse::<i32>() {
+                    let mut pids = notify_pids.lock().expect("Failed to lock");
+                    if let Some(i) = pids.iter().position(|p| *p == pid) {
+                        pids.remove(i);
+                        if pids.is_empty() {
+                            should_stop.store(true, Ordering::Relaxed);
+                            break;
+                        }
+                    }
                 }
             } else if line.starts_with("STOP") {
                 should_stop.store(true, Ordering::Relaxed);

--- a/tests/stop_ignores_unrelated_pid.rs
+++ b/tests/stop_ignores_unrelated_pid.rs
@@ -1,0 +1,68 @@
+//! Regression test for https://github.com/Mic92/direnv-instant/issues/130:
+//! `stop` from a shell that never registered with the daemon (e.g. a
+//! short-lived `fish -c` child inheriting the hook's exported vars) must not
+//! kill the daemon its parent shell is still waiting on.
+
+mod common;
+use common::*;
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[test]
+fn stop_from_unregistered_pid_keeps_daemon_alive() {
+    let sb = Sandbox::new("sleep 3600\n").unwrap();
+    sb.write_stub_tmux("exit 0").unwrap();
+
+    // Long mux delay so the daemon never tries to spawn the watch pane.
+    let mut env = sb.async_env(std::process::id(), 60);
+
+    let out = sb.run(&["start"], &env).unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let exports = parse_exports(&String::from_utf8_lossy(&out.stdout));
+    let stderr_file = PathBuf::from(&exports["__DIRENV_INSTANT_STDERR_FILE"]);
+    let socket_path = stderr_file.parent().unwrap().join("daemon.sock");
+
+    let mut waited = Duration::ZERO;
+    while !socket_path.exists() && waited < Duration::from_secs(3) {
+        std::thread::sleep(Duration::from_millis(100));
+        waited += Duration::from_millis(100);
+    }
+    assert!(socket_path.exists(), "daemon socket never appeared");
+
+    env.insert(
+        "__DIRENV_INSTANT_CURRENT_DIR".into(),
+        exports["__DIRENV_INSTANT_CURRENT_DIR"].clone().into(),
+    );
+
+    // A pid that never sent NOTIFY to this daemon (simulates a `fish -c`
+    // child whose exit hook fires). PID 1 is guaranteed to exist and never
+    // be one of ours.
+    let mut child_env = env.clone();
+    child_env.insert("DIRENV_INSTANT_SHELL_PID".into(), "1".into());
+    let stop = sb.run(&["stop"], &child_env).unwrap();
+    assert!(
+        stop.status.success(),
+        "{}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+
+    // Daemon must still be reachable.
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(
+        std::os::unix::net::UnixStream::connect(&socket_path).is_ok(),
+        "daemon died after stop from an unregistered pid"
+    );
+
+    // Stop from the registered shell pid still shuts it down.
+    let stop = sb.run(&["stop"], &env).unwrap();
+    assert!(stop.status.success());
+    assert!(
+        wait_for_daemon_exit(&socket_path, Duration::from_secs(15)),
+        "daemon still running after stop from owning shell"
+    );
+}


### PR DESCRIPTION

The shell hooks run 'direnv-instant stop' from an exit handler, and the
old STOP command killed the daemon unconditionally. Any short-lived
non-interactive child shell that inherits the hook's exported variables
(e.g. tide's 'fish -c ...' async prompt helper) therefore terminated the
daemon mid-evaluation on every prompt repaint, so the parent shell never
received its environment.

Make the stop path pid-aware: 'stop' and the directory-change path in
'start' now send 'STOP <pid>', and the daemon removes that pid from its
registered shells, shutting down only when none remain and ignoring pids
it never registered. NOTIFY registrations are deduplicated so repeated
prompts don't inflate the list. The bare STOP message keeps its
force-stop semantics for the watch pane's ctrl-c handler.

This also means one interactive shell exiting no longer kills a daemon
that other shells in the same directory are still waiting on.

Fixes https://github.com/Mic92/direnv-instant/issues/130

Also remove old home-manager configuration

Closes #54
Closes #76
