### PR TITLE
mux: add herdr multiplexer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ when it's done. The shell trap then loads the new environment. On revisit, a
 cached environment from the previous run is applied instantly while the daemon
 revalidates in the background.
 
-If direnv takes longer than 4 seconds (configurable), a tmux/zellij/wezterm/kitty
+If direnv takes longer than 4 seconds (configurable), a tmux/zellij/wezterm/kitty/herdr
 split opens showing direnv's output so you can see what it's doing — and ctrl-c
 it if needed.
 
 Supported shells: bash, zsh, fish, nushell.
 Supported multiplexers: tmux, zellij, wezterm, kitty (kitty needs the
-home-manager module).
+home-manager module), herdr.
 
 If you use Nix, pair this with
 [nix-direnv](https://github.com/nix-community/nix-direnv). It caches Nix

--- a/src/mux.rs
+++ b/src/mux.rs
@@ -18,6 +18,7 @@ pub enum Multiplexer {
     Zellij,
     Wezterm,
     Kitty,
+    Herdr,
 }
 
 impl Multiplexer {
@@ -38,6 +39,10 @@ impl Multiplexer {
             return Some(Self::Kitty);
         }
 
+        if env::var("HERDR_ENV").is_ok_and(|x| x == "1") {
+            return Some(Self::Herdr);
+        }
+
         None
     }
 
@@ -48,20 +53,16 @@ impl Multiplexer {
             .and_then(|p| p.to_str().map(String::from))
             .unwrap_or_else(|| "direnv-instant".to_string());
 
-        let mux_bin = match self {
-            Multiplexer::Tmux => "tmux",
-            Multiplexer::Zellij => "zellij",
-            Multiplexer::Wezterm => "wezterm",
-            Multiplexer::Kitty => "kitty",
-        };
-
-        let mut command = Command::new(mux_bin);
+        let mut command;
 
         match self {
+            Multiplexer::Herdr => return spawn_herdr(&bin, ctx),
             Multiplexer::Tmux => {
+                command = Command::new("tmux");
                 command.args(["split-window", "-d", "-l", PANE_HEIGHT]);
             }
             Multiplexer::Zellij => {
+                command = Command::new("zellij");
                 command.args([
                     "action",
                     "new-pane",
@@ -74,11 +75,13 @@ impl Multiplexer {
                 ]);
             }
             Multiplexer::Wezterm => {
+                command = Command::new("wezterm");
                 command.args(["cli", "split-pane", "--bottom", "--cells", PANE_HEIGHT]);
             }
             Multiplexer::Kitty => {
                 let kitty_listen_on =
                     env::var(KITTY_VAR).map_err(|e| Error::other(e.to_string()))?;
+                command = Command::new("kitty");
                 command.args(["@", "--to", kitty_listen_on.as_str()]);
                 command.arg("launch").args(kitty_launch_args());
             }
@@ -94,6 +97,53 @@ impl Multiplexer {
             .spawn()
             .map(|_| ())
     }
+}
+
+/// Herdr needs two steps: split a shell pane, then exec the watcher in it.
+fn spawn_herdr(bin: &str, ctx: &DaemonContext) -> io::Result<()> {
+    let output = Command::new("herdr")
+        .args([
+            "pane",
+            "split",
+            "--current",
+            "--direction",
+            "down",
+            "--no-focus",
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(Error::other(format!(
+            "herdr pane split failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let pane_id = parse_pane_id(&stdout)
+        .ok_or_else(|| Error::other("herdr pane split: no pane_id in response"))?;
+
+    let watch_cmd = format!(
+        "exec {} watch {} {}",
+        shell_quote(bin),
+        shell_quote(&ctx.temp_stderr.to_string_lossy()),
+        shell_quote(&ctx.socket_path.to_string_lossy()),
+    );
+
+    Command::new("herdr")
+        .args(["pane", "run", &pane_id, &watch_cmd])
+        .spawn()
+        .map(|_| ())
+}
+
+fn parse_pane_id(json: &str) -> Option<String> {
+    let needle = "\"pane_id\":\"";
+    let start = json.find(needle)? + needle.len();
+    let end = json[start..].find('"')? + start;
+    Some(json[start..end].to_string())
+}
+
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 fn kitty_launch_args() -> Vec<String> {


### PR DESCRIPTION

Herdr has no single command that splits a pane and runs a program in it,
so split a shell pane below the caller and exec the watcher via
'herdr pane run' so the pane closes when the watcher exits.
